### PR TITLE
Add markdown post system

### DIFF
--- a/content/posts/hello-world.md
+++ b/content/posts/hello-world.md
@@ -1,0 +1,8 @@
+---
+title: Hello World
+date: 2024-06-14
+description: My first post.
+---
+
+This is the **content** of my first post.
+

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/package.json
+++ b/package.json
@@ -11,6 +11,14 @@
   "dependencies": {
     "next": "^14.2.5",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "gray-matter": "^4.0.3",
+    "remark": "^15.0.0",
+    "remark-html": "^16.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
+    "typescript": "^5.0.0"
   }
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { remark } from 'remark';
+import html from 'remark-html';
+
+const postsDirectory = path.join(process.cwd(), 'content/posts');
+
+export function getPostSlugs(): string[] {
+  return fs.readdirSync(postsDirectory).filter((file) => file.endsWith('.md'));
+}
+
+export function getAllPosts() {
+  const slugs = getPostSlugs();
+  return slugs.map((slug) => {
+    const fullPath = path.join(postsDirectory, slug);
+    const { data } = matter(fs.readFileSync(fullPath, 'utf8'));
+    return {
+      slug: slug.replace(/\.md$/, ''),
+      frontMatter: data,
+    };
+  });
+}
+
+export async function getPostBySlug(slug: string) {
+  const realSlug = slug.replace(/\.md$/, '');
+  const fullPath = path.join(postsDirectory, `${realSlug}.md`);
+  const fileContents = fs.readFileSync(fullPath, 'utf8');
+  const { data, content } = matter(fileContents);
+  const processedContent = await remark().use(html).process(content);
+  return {
+    slug: realSlug,
+    frontMatter: data,
+    content: processedContent.toString(),
+  };
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,0 @@
-export default function Home() {
-  return (
-    <main>
-      <h1>Welcome to Next.js!</h1>
-    </main>
-  );
-}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import { GetStaticProps } from 'next';
+import { getAllPosts } from '../lib/posts';
+
+type Post = {
+  slug: string;
+  frontMatter: Record<string, any>;
+};
+
+interface Props {
+  posts: Post[];
+}
+
+export default function Home({ posts }: Props) {
+  return (
+    <main>
+      <h1>Blog Posts</h1>
+      <ul>
+        {posts.map(({ slug, frontMatter }) => (
+          <li key={slug}>
+            <Link href={`/posts/${slug}`}>{frontMatter.title}</Link>
+            {frontMatter.description && <p>{frontMatter.description}</p>}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const posts = getAllPosts();
+  return {
+    props: {
+      posts,
+    },
+  };
+};

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -1,0 +1,31 @@
+import { GetStaticPaths, GetStaticProps } from 'next';
+import { getPostSlugs, getPostBySlug } from '../../lib/posts';
+
+type Props = {
+  post: {
+    slug: string;
+    frontMatter: Record<string, any>;
+    content: string;
+  };
+};
+
+export default function PostPage({ post }: Props) {
+  return (
+    <article>
+      <h1>{post.frontMatter.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: post.content }} />
+    </article>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const slugs = getPostSlugs();
+  const paths = slugs.map((slug) => ({ params: { slug: slug.replace(/\.md$/, '') } }));
+  return { paths, fallback: false };
+};
+
+export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+  const slug = params?.slug as string;
+  const post = await getPostBySlug(slug);
+  return { props: { post } };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add content/posts directory with example markdown post
- parse posts with gray-matter and remark
- generate post pages and index listing using static generation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b9355de230832bad0ff4a0bee54292