### PR TITLE
Add Docker and docker-compose configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+COPY public ./public
+COPY src ./src
+RUN npm install && npm run build
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # blog
-hexo blog host on netlify
+
+Next.js blog.
+
+## Running with Docker Compose
+
+```bash
+docker-compose up --build
+```
+
+The application will be available at http://localhost:3000.
+
+### Environment Variables
+
+Create a `.env` file in the project root or define variables in `docker-compose.yml` under the `environment` key. For example:
+
+```
+NEXT_PUBLIC_ANALYTICS_ID=your-id
+```
+
+These variables are loaded by Next.js during build and runtime.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
## Summary
- add Dockerfile for building Next.js app with node:18-alpine
- add docker-compose.yml exposing port 3000
- document docker-compose usage and environment variable setup in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b938e090f8832baaebcd183ddf7042