### PR TITLE
feat: integrate tiptap editor for admin posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "react-dom": "^18.2.0",
     "gray-matter": "^4.0.3",
     "remark": "^15.0.0",
-    "remark-html": "^16.0.1"
+    "remark-html": "^16.0.1",
+    "@tiptap/react": "^2.6.6",
+    "@tiptap/starter-kit": "^2.6.6"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { EditorContent, useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+
+export default function AdminPage() {
+  const [title, setTitle] = useState('');
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: '',
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const content = editor?.getHTML() || '';
+    await fetch(`${supabaseUrl}/rest/v1/posts`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+      },
+      body: JSON.stringify({ title, content }),
+    });
+    setTitle('');
+    editor?.commands.clearContent();
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">New Post</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full border p-2 rounded"
+          placeholder="Title"
+          required
+        />
+        <EditorContent editor={editor} className="border rounded p-2 min-h-[200px]" />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+          Submit
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,3 +5,7 @@
 body {
   @apply bg-white text-gray-900;
 }
+
+.ProseMirror {
+  @apply outline-none;
+}


### PR DESCRIPTION
## Summary
- add TipTap packages to dependencies
- build admin page with TipTap editor and Supabase submission
- add minimal ProseMirror CSS

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Failed to install required TypeScript dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68b93ded262c832b91d12a8c226cbc6f