### PR TITLE
Add cover image field and upload to blog posts

### DIFF
--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -40,6 +40,7 @@ export const posts = pgTable("posts", {
   slug: text("slug").notNull(),
   title: text("title").notNull(),
   description: text("description"),
+  cover: text("cover"),
   content: text("content"),
   createdAt: timestamp("created_at").defaultNow(),
   status: text("status").notNull().default("draft"), // draft | published

--- a/src/pages/admin/edit/[id].tsx
+++ b/src/pages/admin/edit/[id].tsx
@@ -19,6 +19,7 @@ import { trpc } from "../../../utils/trpc";
 import EditorToolbar from "../../../components/EditorToolbar";
 import { useAdminGuard } from "../../../lib/admin-guard";
 import { Skeleton } from "../../../components/ui/skeleton";
+import React from "react";
 
 export default function AdminEditPage() {
     const router = useRouter();
@@ -39,6 +40,10 @@ export default function AdminEditPage() {
     const [title, setTitle] = useState("");
     const [category, setCategory] = useState("");
     const [tags, setTags] = useState("");
+    const [coverUrl, setCoverUrl] = useState("");
+    const [coverUploading, setCoverUploading] = useState(false);
+    const [coverProgress, setCoverProgress] = useState(0);
+    const getUploadUrl = trpc.r2GetUploadUrl.useMutation();
 
     const editor = useEditor({
         extensions: [
@@ -55,6 +60,7 @@ export default function AdminEditPage() {
         if (current) {
             setTitle(current.title || "");
             editor?.commands.setContent(current.content || "");
+            setCoverUrl((current as any).cover || "");
         }
     }, [current, editor]);
 
@@ -66,6 +72,7 @@ export default function AdminEditPage() {
             id,
             title,
             content: editor?.getHTML() || "",
+            cover: coverUrl || undefined,
             status: publish ? "published" : "draft",
         });
         router.push("/admin");
@@ -121,6 +128,60 @@ export default function AdminEditPage() {
                                 <div className="space-y-2">
                                     <Label htmlFor="title">标题</Label>
                                     <PixelInput id="title" value={title} onChange={(e) => setTitle(e.target.value)} required />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="cover">封面</Label>
+                                    <div className="flex items-center gap-3">
+                                        <PixelInput
+                                            id="cover"
+                                            value={coverUrl}
+                                            placeholder="https://..."
+                                            onChange={(e) => setCoverUrl(e.target.value)}
+                                        />
+                                        <PixelButton
+                                            variant="secondary"
+                                            size="sm"
+                                            disabled={coverUploading}
+                                            onClick={async () => {
+                                                const input = document.createElement('input');
+                                                input.type = 'file';
+                                                input.accept = 'image/*';
+                                                input.onchange = async () => {
+                                                    const file = input.files?.[0];
+                                                    if (!file) return;
+                                                    try {
+                                                        setCoverUploading(true);
+                                                        setCoverProgress(0);
+                                                        const { uploadUrl, publicUrl } = await getUploadUrl.mutateAsync({ filename: file.name, contentType: file.type || 'application/octet-stream' });
+                                                        await new Promise<void>((resolve, reject) => {
+                                                            const xhr = new XMLHttpRequest();
+                                                            xhr.open('PUT', uploadUrl, true);
+                                                            xhr.setRequestHeader('content-type', file.type || 'application/octet-stream');
+                                                            xhr.upload.onprogress = (evt) => {
+                                                                if (evt.lengthComputable) {
+                                                                    const pct = Math.round((evt.loaded / evt.total) * 100);
+                                                                    setCoverProgress(pct);
+                                                                }
+                                                            };
+                                                            xhr.onload = () => {
+                                                                if (xhr.status >= 200 && xhr.status < 300) resolve(); else reject(new Error('Upload failed'));
+                                                            };
+                                                            xhr.onerror = () => reject(new Error('Network error'));
+                                                            xhr.send(file);
+                                                        });
+                                                        setCoverUrl(publicUrl);
+                                                    } finally {
+                                                        setCoverUploading(false);
+                                                    }
+                                                };
+                                                input.click();
+                                            }}
+                                        >{coverUploading ? `上传中 ${coverProgress}%` : '上传图片'}</PixelButton>
+                                    </div>
+                                    {coverUrl && (
+                                        // eslint-disable-next-line @next/next/no-img-element
+                                        <img src={coverUrl} alt="cover" className="mt-2 h-40 w-full object-cover border-4 border-gray-800" />
+                                    )}
                                 </div>
                                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                                     <div className="space-y-2">

--- a/src/pages/admin/new.tsx
+++ b/src/pages/admin/new.tsx
@@ -19,6 +19,7 @@ import { trpc } from "../../utils/trpc";
 import EditorToolbar from "../../components/EditorToolbar";
 import { useAdminGuard } from "../../lib/admin-guard";
 import { Skeleton } from "../../components/ui/skeleton";
+import React from "react";
 
 export default function AdminNewPage() {
     const router = useRouter();
@@ -26,6 +27,10 @@ export default function AdminNewPage() {
     const [title, setTitle] = useState("");
     const [category, setCategory] = useState("");
     const [tags, setTags] = useState("");
+    const [coverUrl, setCoverUrl] = useState("");
+    const [coverUploading, setCoverUploading] = useState(false);
+    const [coverProgress, setCoverProgress] = useState(0);
+    const getUploadUrl = trpc.r2GetUploadUrl.useMutation();
     const editor = useEditor({
         extensions: [
             StarterKit.configure({ codeBlock: false }),
@@ -46,7 +51,7 @@ export default function AdminNewPage() {
         const content = editor?.getHTML() || "";
         const tagsArr = tags.split(",").map((t) => t.trim()).filter((t) => t.length > 0);
         const status: "draft" | "published" = publish ? "published" : "draft";
-        return { title, content, category: category || undefined, tags: tagsArr, status };
+        return { title, content, cover: coverUrl || undefined, category: category || undefined, tags: tagsArr, status };
     };
 
     const handleCreate = async (publish: boolean) => {
@@ -117,6 +122,60 @@ export default function AdminNewPage() {
                         <div className="space-y-2">
                             <Label htmlFor="title">标题</Label>
                             <PixelInput id="title" value={title} onChange={(e) => setTitle(e.target.value)} required />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="cover">封面</Label>
+                            <div className="flex items-center gap-3">
+                                <PixelInput
+                                    id="cover"
+                                    value={coverUrl}
+                                    placeholder="https://..."
+                                    onChange={(e) => setCoverUrl(e.target.value)}
+                                />
+                                <PixelButton
+                                    variant="secondary"
+                                    size="sm"
+                                    disabled={coverUploading}
+                                    onClick={async () => {
+                                        const input = document.createElement('input');
+                                        input.type = 'file';
+                                        input.accept = 'image/*';
+                                        input.onchange = async () => {
+                                            const file = input.files?.[0];
+                                            if (!file) return;
+                                            try {
+                                                setCoverUploading(true);
+                                                setCoverProgress(0);
+                                                const { uploadUrl, publicUrl } = await getUploadUrl.mutateAsync({ filename: file.name, contentType: file.type || 'application/octet-stream' });
+                                                await new Promise<void>((resolve, reject) => {
+                                                    const xhr = new XMLHttpRequest();
+                                                    xhr.open('PUT', uploadUrl, true);
+                                                    xhr.setRequestHeader('content-type', file.type || 'application/octet-stream');
+                                                    xhr.upload.onprogress = (evt) => {
+                                                        if (evt.lengthComputable) {
+                                                            const pct = Math.round((evt.loaded / evt.total) * 100);
+                                                            setCoverProgress(pct);
+                                                        }
+                                                    };
+                                                    xhr.onload = () => {
+                                                        if (xhr.status >= 200 && xhr.status < 300) resolve(); else reject(new Error('Upload failed'));
+                                                    };
+                                                    xhr.onerror = () => reject(new Error('Network error'));
+                                                    xhr.send(file);
+                                                });
+                                                setCoverUrl(publicUrl);
+                                            } finally {
+                                                setCoverUploading(false);
+                                            }
+                                        };
+                                        input.click();
+                                    }}
+                                >{coverUploading ? `上传中 ${coverProgress}%` : '上传图片'}</PixelButton>
+                            </div>
+                            {coverUrl && (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img src={coverUrl} alt="cover" className="mt-2 h-40 w-full object-cover border-4 border-gray-800" />
+                            )}
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                             <div className="space-y-2">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,7 +49,7 @@ export default function Home() {
                   : ""
               }
               category={post.category?.name || "未分类"}
-              imageUrl="/placeholder.png"
+              imageUrl={(post as any).cover || "/placeholder.png"}
               readTime="约 3 分钟"
             />
           ))}

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -98,13 +98,14 @@ export const appRouter = t.router({
       z.object({
         title: z.string().min(1),
         content: z.string().optional().default(""),
+        cover: z.string().url().optional(),
         category: z.string().optional(),
         tags: z.array(z.string()).optional().default([]),
         status: z.enum(["draft", "published"]).optional().default("draft"),
       })
     )
     .mutation(async ({ input }) => {
-      const { title, content, category, tags: tagNames, status } = input;
+      const { title, content, cover, category, tags: tagNames, status } = input;
       const slugBase = title
         .trim()
         .toLowerCase()
@@ -146,12 +147,13 @@ export const appRouter = t.router({
 
         const insertedPost = await tx
           .insert(posts)
-          .values({ title, content, slug, categoryId, status })
+          .values({ title, content, slug, categoryId, status, cover })
           .returning({
             id: posts.id,
             title: posts.title,
             slug: posts.slug,
             content: posts.content,
+            cover: posts.cover,
             categoryId: posts.categoryId,
             createdAt: posts.createdAt,
             status: posts.status,
@@ -221,6 +223,7 @@ export const appRouter = t.router({
         id: z.number(),
         title: z.string().min(1).optional(),
         content: z.string().optional(),
+        cover: z.string().url().optional().or(z.literal("").transform(v => undefined)),
         status: z.enum(["draft", "published"]).optional(),
       })
     )

--- a/supabase/migrations/0002_add_cover_to_posts.sql
+++ b/supabase/migrations/0002_add_cover_to_posts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "posts" ADD COLUMN "cover" text;

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -16,5 +16,13 @@
       "tag": "0001_red_reaper",
       "breakpoints": true
     }
+    ,
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1757050000000,
+      "tag": "0002_add_cover_to_posts",
+      "breakpoints": true
+    }
   ]
 }


### PR DESCRIPTION
Add `cover` field to blog posts, enable cover image upload in admin, and display covers on the homepage.

---
<a href="https://cursor.com/background-agent?bcId=bc-a796d66d-f057-46ac-adde-6b1775cde096">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a796d66d-f057-46ac-adde-6b1775cde096">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

